### PR TITLE
Update image and cluster resource to use the gcloudKey

### DIFF
--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -3,7 +3,7 @@ resources:
     type: image
     flags:
       - deploy-gke-basic
-    integration: dr-ecr
+    integration: dr-gcloud
     pointer:
       sourceName: "gcr.io/sample-gke/basic-node-deploy-gke"
     seed:
@@ -39,7 +39,7 @@ resources:
     type: cluster
     flags:
       - deploy-gke-basic
-    integration: dr-gke
+    integration: dr-gcloud
     pointer:
       sourceName : "deploy-gke-basic" #name of the cluster to which we are deploying
       region: "us-central-1f"

--- a/shippable.yml
+++ b/shippable.yml
@@ -44,5 +44,5 @@ integrations:
   # adding docker hub integration so that credentials are available to CI Job
   # http://docs.shippable.com/integrations/imageRegistries/ecr/
   hub:
-    - integrationName: dr-gcr
-      type: gcr
+    - integrationName: dr-gcloud
+      type: gcloudKey


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/9269

Build Link:
- https://app.shippable.com/github/mohit5it9/jobs/deploy-gke-basic-deploy/builds/59f2f5d25f11230700f14065/console

- https://app.shippable.com/github/mohit5it9/deploy-gke-basic/runs/3/1/console

YML's used were exactly same as described in the devops recipes (only integration name and images were different, as i dont have access to those images)
Jobs YML: https://github.com/mohit5it9/sample_pipelines/blob/deploy-gke-basic/shippable.jobs.yml
Resources YML: https://github.com/mohit5it9/sample_pipelines/blob/deploy-gke-basic/shippable.resources.yml
Shippable YML: https://github.com/mohit5it9/deploy-gke-basic/blob/devops-recipes/shippable.yml
